### PR TITLE
Upgrade ember-cli-htmlbars to remove ember-cli-app-version warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.1.2",
     "ember-cli": "1.13.8",
-    "ember-cli-app-version": "0.5.0",
+    "ember-cli-app-version": "^2.0.0",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.0.1",
-    "ember-cli-htmlbars": "0.7.9",
-    "ember-cli-htmlbars-inline-precompile": "^0.2.0",
+    "ember-cli-htmlbars": "^1.1.1",
+    "ember-cli-htmlbars-inline-precompile": "^0.3.6",
     "ember-cli-ic-ajax": "0.2.1",
     "ember-cli-inject-live-reload": "^1.3.1",
     "ember-cli-qunit": "^1.0.0",
@@ -48,7 +48,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.3",
-    "ember-cli-htmlbars": "0.7.9",
+    "ember-cli-htmlbars": "^1.1.1",
     "emberx-select": "2.2.2"
   },
   "ember-addon": {


### PR DESCRIPTION
This gets rid of

> DEPRECATION: Overriding init without calling this._super is deprecated. Please call `this._super.init && this._super.init.apply(this, arguments);` addon: `ember-cli-htmlbars`